### PR TITLE
chore: add default security policy on org-level

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Contact [security@ithaca.xyz](mailto:security@ithaca.xyz).


### PR DESCRIPTION
By adding it to `.github` it provides all repo's in the org with a default security policy `SECURITY.md`. Any existing ones will simply override the org-level one.

> You can add default community health files to a public repository called .github and GitHub will use and display default files for any repository owned by the account that does not have its own file of that type in the following order:
> 
> The .github folder
> The root of the repository
> The docs folder
>
> If no corresponding file is found in the current repository, GitHub will use the default file from the .github repository, following the same order of precedence.

Ref: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file